### PR TITLE
cask name has no -app suffix any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo /Applications/RabbitMQ.app/Contents/Resources/Vendor/rabbitmq/sbin | sudo t
 You can also install RabbitMQ.app with [Homebrew Cask](http://caskroom.io/).
 
 ```bash
-$ brew cask install rabbitmq-app
+$ brew cask install rabbitmq
 ```
 
 ### Credits


### PR DESCRIPTION
I could install it with `brew cask install rabbitmq` but `brew cask install rabbitmq-app` failed.