### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo /Applications/RabbitMQ.app/Contents/Resources/Vendor/rabbitmq/sbin | sudo t
 You can also install RabbitMQ.app with [Homebrew Cask](http://caskroom.io/).
 
 ```bash
-$ brew cask install rabbitmq
+$ brew install --cask rabbitmq
 ```
 
 ### Credits


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524